### PR TITLE
fix: use correct arguments for ConP on TH >= 2.18.0.0

### DIFF
--- a/src/ExceptionVia.hs
+++ b/src/ExceptionVia.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes   #-}
 {-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DerivingStrategies    #-}
 {-# LANGUAGE DerivingVia           #-}
 {-# LANGUAGE FlexibleContexts      #-}
@@ -212,5 +213,9 @@ mkHierarchy nm = do
   [d|
     instance Hierarchy (conT nm) where
       toParent = $(conE constrName)
+#if MIN_VERSION_template_haskell(2,18,0)
+      fromParent $(pure $ ConP constrName [] [VarP (mkName "e")]) = cast e
+#else
       fromParent $(pure $ ConP constrName [VarP (mkName "e")]) = cast e
+#endif
     |]


### PR DESCRIPTION
I think this does the job. It works on my machine for GHC 9.4.5 but I can't test for the resolver set in the stack config because there doesn't appear to be a GHC-8.8 compiled for apple silicon.