### PR TITLE
fix: add missing sigil to instance declaration

### DIFF
--- a/src/ExceptionVia.hs
+++ b/src/ExceptionVia.hs
@@ -211,7 +211,7 @@ mkHierarchy nm = do
   constrName <- getConName con
 
   [d|
-    instance Hierarchy (conT nm) where
+    instance Hierarchy $(conT nm) where
       toParent = $(conE constrName)
 #if MIN_VERSION_template_haskell(2,18,0)
       fromParent $(pure $ ConP constrName [] [VarP (mkName "e")]) = cast e


### PR DESCRIPTION
As written the code makes an instance for (conT nm) when it should instead be splicing $(conT nm) into the instance head.