### PR TITLE
Fix/add exception instance

### DIFF
--- a/src/ExceptionVia.hs
+++ b/src/ExceptionVia.hs
@@ -107,6 +107,13 @@ import           Language.Haskell.TH.Quote
 newtype ExceptionVia big lil = ExceptionVia { unExceptionVia :: lil }
   deriving Show
 
+
+instance (Hierarchy big, Exception big, Exception lil) => Exception (ExceptionVia big lil) where
+  toException (ExceptionVia e) = toException (toParent @big e)
+  fromException e =
+    ExceptionVia
+      <$> (fromParent =<< fromException @big e)
+
 -- | A concise operator alias for 'ExceptionVia'.
 --
 -- Given a wrapper exception type like @SomeCompilerException@, you can

--- a/src/ExceptionVia.hs
+++ b/src/ExceptionVia.hs
@@ -211,7 +211,7 @@ mkHierarchy nm = do
   constrName <- getConName con
 
   [d|
-    instance Hierarchy (conT nm) where
+    instance Hierarchy $(conT nm) where
       toParent = $(conE constrName)
 #if MIN_VERSION_template_haskell(2,18,0)
       fromParent $(pure $ ConP constrName [] [VarP (mkName "e")]) = cast e


### PR DESCRIPTION
Fixes #4 

This is just a simple implementation of the Exception instance to allow DeriveVia.

Includes #3 because otherwise the template haskell code doesn't work for generating hierarchies, but if that is merged this can be rebased on top of it to be a single commit.